### PR TITLE
Set the task to fail if no ispac is found

### DIFF
--- a/BuildSSISTask/BuildSSISTask.ps1
+++ b/BuildSSISTask/BuildSSISTask.ps1
@@ -126,6 +126,7 @@ try	{
 	if (!$outputFile)
 	{
 		Write-Host "##vso[task.logissue type=error;]Test Output: No .ispac file found in $workingFolder!"
+        Write-Host "##vso[task.complete result=Failed;]There was an error"
 	}
 	Trace-VstsLeavingInvocation $MyInvocation
 }

--- a/BuildSSISTask/BuildSSISTask.ps1
+++ b/BuildSSISTask/BuildSSISTask.ps1
@@ -126,7 +126,7 @@ try	{
 	if (!$outputFile)
 	{
 		Write-Host "##vso[task.logissue type=error;]Test Output: No .ispac file found in $workingFolder!"
-        Write-Host "##vso[task.complete result=Failed;]There was an error"
+        Write-Host "##vso[task.complete result=Failed;]"
 	}
 	Trace-VstsLeavingInvocation $MyInvocation
 }


### PR DESCRIPTION
#3 
Simply setting the task to fail when no ISPAC is found. I've only set it on that one error message though. Not sure if it should be added for others but it seems to me that if you've not created an ISPAC the task has definitely failed.