### PR TITLE
Fixed ProjectParameters

### DIFF
--- a/DeploySSISTask/DeploySSISTask.ps1
+++ b/DeploySSISTask/DeploySSISTask.ps1
@@ -73,23 +73,24 @@ try {
     # Set project parameters
     Write-Host (Get-VstsLocString -Key SetParameters)
     $project = $folder.Projects[$ProjectName]
-    $parameterLines = $ProjectParameters -split '[\r\n]'
-    foreach ($parameterLine in $parameterLines) {
-        $parameter = $parameterLine -split '='
+    if ($project.Parameters.Count -neq 0) {
+    	$parameterLines = $ProjectParameters -split '[\r\n]'
+    	foreach ($parameterLine in $parameterLines) {
+        	$parameter = $parameterLine -split '='
 
-        if ($project.Parameters.Contains($parameter[0])) {
-            Write-Host (Get-VstsLocString -Key SettingParameter0ValueTo1 -ArgumentList $parameter[0],$parameter[1])
+        	if ($project.Parameters.Contains($parameter[0])) {
+            	Write-Host (Get-VstsLocString -Key SettingParameter0ValueTo1 -ArgumentList $parameter[0],$parameter[1])
 
-            $project.Parameters[$parameter[0]].Set(
-                $project.Parameters[$parameter[0]].ValueType,
-                $parameter[1]
-            )
-        }
-        else {
-            Write-Warning (Get-VstsLocString -Key Parameter0NotValid -ArgumentList $parameter[0])
-        }
+            	$project.Parameters[$parameter[0]].Set(
+                	$project.Parameters[$parameter[0]].ValueType,
+                	$parameter[1]
+            	)
+        	}
+        	else {
+	            Write-Warning (Get-VstsLocString -Key Parameter0NotValid -ArgumentList $parameter[0])
+	        }
+	    }
     }
-    
     $project.Alter()
 
 } catch {

--- a/DeploySSISTask/DeploySSISTask.ps1
+++ b/DeploySSISTask/DeploySSISTask.ps1
@@ -73,7 +73,7 @@ try {
     # Set project parameters
     Write-Host (Get-VstsLocString -Key SetParameters)
     $project = $folder.Projects[$ProjectName]
-    if ($project.Parameters.Count -neq 0) {
+    if ($project.Parameters.Count -gt 0) {
     	$parameterLines = $ProjectParameters -split '[\r\n]'
     	foreach ($parameterLine in $parameterLines) {
         	$parameter = $parameterLine -split '='


### PR DESCRIPTION
The Contains method returned an error when a project had no ProjectParameters because the Parameters collection was empty. New code checks if the project does have ProjectParameters and if not, does not iterate over the ProjectParameters values.