### PR TITLE
Fixed field type from multiline to multiLine

### DIFF
--- a/DeploySSISTask/task.json
+++ b/DeploySSISTask/task.json
@@ -69,7 +69,7 @@
         },
         {
             "name": "ProjectParameters",
-            "type": "multiline",
+            "type": "multiLine",
             "label": "Project Parameters",
             "defaultValue": "",
             "required": false,


### PR DESCRIPTION
The type of the ProjectParameters field  was in the wrong casing, so the field would not show up in TFS2015. 
It is now corrected to multiLine